### PR TITLE
fixed free(ip) crash

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -556,7 +556,7 @@ static Handle<Value> FindDevice(const Arguments& args) {
       );
     }
     String::AsciiValue ipstr(args[0]->ToString());
-    ip = (char*)malloc(sizeof(*ipstr));
+    ip = (char*)malloc(ipstr.length());
     strcpy(ip, *ipstr);
   }
 


### PR DESCRIPTION
sizeof(*ipstr) would always return 4 on a 32-bit system and 8 on a 64-bit system. (i.e. the size of a char pointer?)
This caused the free(ip); on line 596 to crash.

I'm just a day into c++ and pointers.
- I'm wondering why/how 'ip' was still able to store the entire ip.
- If it stored the 'ip' correctly, why did free() fail? memory corruption during malloc or strcpy?

Btw thanks for the comment on 
http://www.techresx.com/programming/packet-capture-nodejs-edgejs/
