### PR TITLE
Fix for webpack builds

### DIFF
--- a/lib/Cap.js
+++ b/lib/Cap.js
@@ -1,6 +1,6 @@
 var EventEmitter = require('events').EventEmitter;
 
-var addon = require('../build/Release/cap');
+var addon = require('../build/Release/cap.node');
 
 addon.Cap.prototype.__proto__ = EventEmitter.prototype;
 addon.Cap.findDevice = addon.findDevice;


### PR DESCRIPTION
Hey.
To include the cap module within a webpack build we can use the webpack plugin "node-loader" which will trace the .node files and somehow embedd them in the bundle.

These module seem to require the .node extension and since node doesn't have problems with extensions I added the extension to the require.