### PR TITLE
Improve README.md requirements speach

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Requirements
 
 * **Node.js:** [v4.0.0 or newer](http://nodejs.org/) 
 
-* **For Windows:** (Re)install [Npcap](https://nmap.org/npcap/) with [WinPcap API-compatible Mode](https://i.imgur.com/5dqfDBl.png) (by default this setting is disabled).
+* **For Windows:** (Re)install [Npcap](https://nmap.org/npcap/) with [WinPcap API-compatible Mode](https://user-images.githubusercontent.com/18501150/83390315-e6a15500-a3f1-11ea-9826-3072d141c417.png) (by default this setting is disabled). 
 
 * **For \*nix:** libpcap and libpcap-dev/libpcap-devel packages
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A cross-platform binding for performing packet capturing with [node.js](http://n
 Requirements
 ============
 
-* [node.js](http://nodejs.org/) -- v4.0.0 or newer
+* **Node.js:** [v4.0.0 or newer](http://nodejs.org/) 
 
-* For Windows: [Npcap with WinPcap compatibility](https://nmap.org/npcap/)
+* **For Windows:** (Re)install [Npcap](https://nmap.org/npcap/) with [WinPcap API-compatible Mode](https://i.imgur.com/5dqfDBl.png) (by default this setting is disabled).
 
-* For *nix: libpcap and libpcap-dev/libpcap-devel packages
+* **For \*nix:** libpcap and libpcap-dev/libpcap-devel packages
 
 
 Install


### PR DESCRIPTION
Fix: #90 

I had already npcap installed on my computer with wireshark but without compatibility mode... I thought I already have it (and when I read the readme, i didn't understand that I should reinstall this dependency and check "Compatibility mode").