### PR TITLE
Resolve module load issue if npcap installed without api-compatible mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+dist/
+build/
+node_modules/
+Debug/
+Release/
+*.lock
+*.log
+npm-debug.log*
+
+.idea/
+.vscode/
+.DS_Store
+
+*/*.bin
+prebuilds/
+package-lock.json

--- a/binding.gyp
+++ b/binding.gyp
@@ -27,6 +27,12 @@
               },
             }],
           ],
+          'msvs_settings': {
+            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+            'VCLinkerTool':{
+              'DelayLoadDLLs':['wpcap.dll']
+            }
+          }
         }, {
           # POSIX
           'link_settings': {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
-{ "name": "cap",
+{
+  "name": "cap",
   "version": "0.2.1",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "A cross-platform binding for performing packet capturing with node.js",
@@ -10,8 +11,24 @@
     "install": "node-gyp rebuild",
     "test": "node test/test.js"
   },
-  "engines": { "node": ">=4.0.0" },
-  "keywords": [ "pcap", "packet", "capture", "libpcap", "winpcap" ],
-  "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/cap/raw/master/LICENSE" } ],
-  "repository" : { "type": "git", "url": "http://github.com/mscdex/cap.git" }
+  "engines": {
+    "node": ">=4.0.0"
+  },
+  "keywords": [
+    "pcap",
+    "packet",
+    "capture",
+    "libpcap",
+    "winpcap"
+  ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/mscdex/cap/raw/master/LICENSE"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/mscdex/cap.git"
+  }
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -26,6 +26,24 @@
     (set_immediate_fn)(dlsym(_pcap_lib_handle, "pcap_set_immediate_mode"));
 #endif
 
+#ifdef _WIN32
+#include <tchar.h>
+BOOL LoadNpcapDlls()
+{
+  _TCHAR npcap_dir[512];
+  UINT len;
+  len = GetSystemDirectory(npcap_dir, 480);
+  if (!len) {
+    return FALSE;
+  }
+  _tcscat_s(npcap_dir, 512, _T("\\Npcap"));
+  if (SetDllDirectory(npcap_dir) == 0) {
+    return FALSE;
+  }
+  return TRUE;
+}
+#endif
+
 using namespace node;
 using namespace v8;
 
@@ -617,6 +635,14 @@ static NAN_METHOD(FindDevice) {
 
 extern "C" {
   void init(Local<Object> target) {
+#ifdef _WIN32
+    /* Load Npcap and its functions. */
+    if (!LoadNpcapDlls())
+    {
+      exit(1);
+    }
+#endif
+
     Nan::HandleScope scope;
     Pcap::Initialize(target);
     Nan::Set(target,


### PR DESCRIPTION
There will be a module load issue if api-compatible mode is not checked while installing npcap on windows. I made a fix for it.
What I do:
1. Add LoadNpcapDlls method when invoke this node addon.
2. Update binding.gyp, append wpcap.dll as delay load dll.

There is a document from npcap site, I just followed the description in this link. 
https://npcap.com/guide/npcap-devguide.html#npcap-feature-native-dll